### PR TITLE
Document response, data, error, and close events

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,16 @@ download(files, 'bar');
 ### download(url, dest, opts)
 
 Download a file or an array of files to a given destination. Returns an EventEmitter 
-with three possible events — `response`, `data` and `error`.
+that emits the following possible events:
+
+* `response` - Relayed when the underlying `http.ClientRequest` emits the same
+  event.  Listeners called with a `http.IncomingMessage` instance.
+* `data` - Relayed when the underlying `http.IncomingMessage` emits the same
+  event.  Listeners called with a `Buffer` instance.
+* `error` - Relayed when the underlying `http.ClientRequest` emits the same
+  event or when the response status code is not in the 200s.  Listeners called
+  with an `Error` instance (in the first case) or the response status code.
+* `close` - Relayed when the underlying `stream.Duplex` emits the same event.
 
 ## Options
 


### PR DESCRIPTION
It looks like the `close` event is not currently documented.  This adds consistent docs for all four events.
