### PR TITLE
allow complex url description when extracting

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,8 +63,8 @@ module.exports = function (url, dest, opts) {
 
             stream.emit('response', res);
 
-            if (opts.extract && decompress.canExtract(url, mime)) {
-                var ext = decompress.canExtract(url) ? url : mime;
+            if (opts.extract && decompress.canExtract(opts.url, mime)) {
+                var ext = decompress.canExtract(opts.url) ? opts.url : mime;
 
                 end = decompress.extract({
                     ext: ext,


### PR DESCRIPTION
If you try to use both (1) the complex url option `{url: 'http://example.com/file.zip', name: 'othername.zip'}` and (2) the `extract: true` option, you will get an error. The code passed the `url` object to `decompress.canExtract` instead of a string.

This PR fixes the issue.
