### PR TITLE
decompress.canExtract is obsolete, in v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url"
   ],
   "dependencies": {
-    "decompress": "^0.2.0",
+    "decompress": "0.2.4",
     "each-async": "^0.1.1",
     "get-stdin": "^0.1.0",
     "get-urls": "^0.1.1",


### PR DESCRIPTION
https://github.com/kevva/download/blob/master/index.js#L70 references canExtract, which has been removed in 0.3.0 by @kevva

This pull request fixes the dependency version at 0.2.4.
