### PR TITLE
update decompress version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url"
   ],
   "dependencies": {
-    "decompress": "^0.2.0",
+    "decompress": "^0.3.1",
     "each-async": "^0.1.1",
     "get-stdin": "^0.1.0",
     "get-urls": "^0.1.1",


### PR DESCRIPTION
old decompress depend a renamed node module: extname(now ext-name), so please update it.
But, I can't figure out which version is best.
