### PR TITLE
Update dependencies and fix error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,12 +118,16 @@ Download.prototype.run = function (cb) {
 
 		var stream = got(get.url, this.opts);
 
-		stream.on('error', done);
 		stream.on('response', function (res) {
 			this.ware.run(res, get.url);
 		}.bind(this));
 
 		readAllStream(stream, null, function (err, data) {
+			if (err) {
+				done(err);
+				return;
+			}
+
 			var dest = get.dest || this.dest();
 			var fileStream = this.createStream(this.createFile(get.url, data), dest);
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "email": "kevinmartensson@gmail.com",
     "url": "github.com/kevva"
   },
-  "bin": "cli.js",
   "engines": {
     "node": ">=0.10.0"
   },
@@ -35,9 +34,9 @@
     "gulp-rename": "^1.2.0",
     "is-url": "^1.2.0",
     "object-assign": "^2.0.0",
-    "read-all-stream": "^1.0.2",
+    "read-all-stream": "^3.0.0",
     "stream-combiner2": "^1.0.2",
-    "through2": "^0.6.1",
+    "through2": "^2.0.0",
     "vinyl": "^0.4.3",
     "vinyl-fs": "^1.0.0",
     "ware": "^1.2.0"


### PR DESCRIPTION
`read-all-stream@~1` using `on('data')` handler, which forces stream to fall into Stream1 mode and flush all data.

This should be related to #67 (but will not fix it yet).