### PR TITLE
Don't pass response stream directly into plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,9 @@ Download.prototype.run = function (cb) {
 
 		stream.on('error', done);
 		stream.on('response', function (res) {
-			this.ware.run(res, get.url);
+			stream.headers = res.headers;
+			stream.statusCode = res.statusCode;
+			this.ware.run(stream, get.url);
 		}.bind(this));
 
 		readAllStream(stream, null, function (err, data) {

--- a/test/test.js
+++ b/test/test.js
@@ -233,3 +233,22 @@ test('expose the response object', function (t) {
 			t.assert(files[0].url === 'http://foo.com/test-file.zip', files[0].url);
 		});
 });
+
+test('do not flush data to plugin', function (t) {
+	t.plan(7);
+
+	var scope = nock('http://foo.com')
+		.get('/test-file.zip')
+		.replyWithFile(200, fixture('test-file.zip'));
+
+	new Download()
+		.get('http://foo.com/test-file.zip')
+		.use(function (res, url) {
+			res.on('data', function () {});
+		})
+		.run(function (err, files) {
+			t.assert(!err, err);
+			t.assert(scope.isDone(), scope.isDone());
+			t.assert(files[0].contents.length === 166, files[0].contents.length);
+		});
+});


### PR DESCRIPTION
Temproary fix for early stream flushing. Maybe this should be done directly in `got`.

Fixes #67