### PR TITLE
Update got to 3.3.1, add redirect test

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "concat-stream": "^1.4.7",
     "each-async": "^1.0.0",
     "filenamify": "^1.0.1",
-    "got": "^2.3.2",
+    "got": "~3.3.1",
     "gulp-decompress": "^1.0.2",
     "gulp-rename": "^1.2.0",
     "is-url": "^1.2.0",

--- a/test/test.js
+++ b/test/test.js
@@ -190,7 +190,32 @@ test('error on 404', function (t) {
 		.run(function (err) {
 			t.assert(scope.isDone(), scope.isDone());
 			t.assert(err.code === 404, err.code);
-			t.assert(err.message === 'http://foo.com response code is 404 (Not Found)', err.message);
+			t.assert(err.message === 'GET http://foo.com/ response code is 404 (Not Found)', err.message);
+		});
+});
+
+test('follows 302 redirect', function (t) {
+	t.plan(5);
+
+	var scope = nock('http://foo.com')
+		.get('/test-file.zip')
+		.reply(302, null, { location: 'http://foo.com/redirected.zip' })
+    .get('/redirected.zip')
+    .replyWithFile(200, fixture('test-file.zip'));
+
+  var called = 0;
+
+	new Download()
+		.get('http://foo.com/test-file.zip')
+		.use(function () {
+			called++;
+		})
+		.run(function (err, files) {
+			t.assert(!err, err);
+			t.assert(scope.isDone(), scope.isDone());
+			t.assert(files[0].path === 'test-file.zip', files[0].path);
+			t.assert(files[0].url === 'http://foo.com/test-file.zip', files[0].url);
+			t.assert(called === 1, 'plugin called ' + called + ' times');
 		});
 });
 


### PR DESCRIPTION
Fixes #74. The added test case asserts that the redirect is followed and plugin is called only once.

I tried updating `got` to the latest 4.1.1. Required one change, calling `got.stream(..)` instead of `got(..)`. But then the 404 test case failed, and I don't have time to investigate further.