### PR TITLE
Consider `strict-ssl` npm config

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,10 @@ function Download(opts) {
 		return new Download(opts);
 	}
 
-	this.opts = objectAssign({encoding: null}, opts);
+	this.opts = objectAssign({
+		encoding: null,
+		rejectUnauthorized: process.env.npm_config_strict_ssl !== 'false'
+	}, opts);
 	this.ware = new Ware();
 }
 


### PR DESCRIPTION
fix https://github.com/kevva/download/issues/97
fix https://github.com/imagemin/optipng-bin/issues/74
close https://github.com/kevva/download/issues/101

If [`strict-ssl`](https://docs.npmjs.com/misc/config#strict-ssl) npm config is disabled, this module doesn't emit errors even if the server certificate is not verified.

@kevva, otherwise, should this feature is included in https://github.com/kevva/bin-build?
