### PR TITLE
Removing a encoding parameter, that would be overwritten

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,6 @@ module.exports = (uri, output, opts) => {
 	}
 
 	opts = Object.assign({
-		encoding: null,
 		rejectUnauthorized: process.env.npm_config_strict_ssl !== 'false'
 	}, opts);
 


### PR DESCRIPTION
The property 'encoding' in index.js always be overwritten when it is setted in download options, and the got module treats the 'undefined' encoding as utf-8. So, it's a little detail, but I think it's can be removed.