### PR TITLE
Handle querystrings and content-disposition

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const url = require('url');
 const caw = require('caw');
+const cd = require('content-disposition');
 const decompress = require('decompress');
 const filenamify = require('filenamify');
 const getStream = require('get-stream');
@@ -12,27 +13,23 @@ const pify = require('pify');
 
 const fsP = pify(fs);
 
-const createPromise = (uri, output, stream, opts) => {
-	const response = opts.encoding === null ? getStream.buffer(stream) : getStream(stream, opts);
+function getFilename(res) {
+	const header = res.headers['content-disposition'];
+	if (!header) {
+		return filenameFromPath(res);
+	}
 
-	return response.then(data => {
-		if (!output && opts.extract) {
-			return decompress(data, opts);
-		}
+	const parsed = cd.parse(res.headers['content-disposition']);
+	if (parsed.type === 'attachment' && parsed.parameters && parsed.parameters.filename) {
+		return parsed.parameters.filename;
+	}
 
-		if (!output) {
-			return data;
-		}
+	return filenameFromPath(res);
+}
 
-		if (opts.extract) {
-			return decompress(data, path.dirname(output), opts);
-		}
-
-		return pify(mkdirp)(path.dirname(output))
-			.then(() => fsP.writeFile(output, data))
-			.then(() => data);
-	});
-};
+function filenameFromPath(res) {
+	return path.basename(url.parse(res.requestUrl).pathname);
+}
 
 module.exports = (uri, output, opts) => {
 	if (typeof output === 'object') {
@@ -53,8 +50,32 @@ module.exports = (uri, output, opts) => {
 
 	const agent = caw(opts.proxy, {protocol});
 	const stream = got.stream(uri, Object.assign(opts, {agent}));
-	const dest = output ? path.join(output, filenamify(path.basename(uri))) : null;
-	const promise = createPromise(uri, dest, stream, opts);
+	const promise = new Promise((resolve, reject) => {
+		stream.on('error', reject);
+		stream.on('response', res => {
+			const getData = opts.encoding === null ? getStream.buffer(stream) : getStream(stream, opts);
+
+			getData.then(data => {
+				if (!output && opts.extract) {
+					return resolve(decompress(data, opts));
+				}
+
+				if (!output) {
+					return resolve(data);
+				}
+
+				output = path.join(output, filenamify(getFilename(res)));
+
+				if (opts.extract) {
+					return resolve(decompress(data, path.dirname(output), opts));
+				}
+
+				return pify(mkdirp)(path.dirname(output))
+					.then(() => fsP.writeFile(output, data))
+					.then(() => resolve(data));
+			});
+		});
+	});
 
 	stream.then = promise.then.bind(promise);
 	stream.catch = promise.catch.bind(promise);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   ],
   "dependencies": {
     "caw": "^2.0.0",
+    "content-disposition": "^0.5.2",
     "decompress": "^4.0.0",
     "filenamify": "^2.0.0",
     "get-stream": "^3.0.0",

--- a/test.js
+++ b/test.js
@@ -71,13 +71,13 @@ test('follow redirects', async t => {
 	t.true(isZip(await m('http://foo.bar/redirect.zip')));
 });
 
-test('hanle query string', async t => {
+test('handle query string', async t => {
 	await m('http://foo.bar/querystring.zip?param=value', __dirname);
 	t.true(await pathExists(path.join(__dirname, 'querystring.zip')));
 	await fsP.unlink(path.join(__dirname, 'querystring.zip'));
 });
 
-test('hanle content dispositon', async t => {
+test('handle content dispositon', async t => {
 	await m('http://foo.bar/dispo', __dirname);
 	t.true(await pathExists(path.join(__dirname, 'dispo.zip')));
 	await fsP.unlink(path.join(__dirname, 'dispo.zip'));

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import cd from 'content-disposition';
 import getStream from 'get-stream';
 import isZip from 'is-zip';
 import nock from 'nock';
@@ -18,7 +19,13 @@ test.before(() => {
 		.reply(404)
 		.get('/foo.zip')
 		.replyWithFile(200, path.join(__dirname, 'fixture.zip'))
-		.get('/foo?bar.zip')
+		.get('/querystring.zip').query({param: 'value'})
+		.replyWithFile(200, path.join(__dirname, 'fixture.zip'))
+		.get('/dispo')
+		.replyWithFile(200, path.join(__dirname, 'fixture.zip'), {
+			'Content-Disposition': cd('dispo.zip')
+		})
+		.get('/foo*bar.zip')
 		.replyWithFile(200, path.join(__dirname, 'fixture.zip'))
 		.get('/large.bin')
 		.reply(200, randomBuffer(7928260))
@@ -51,15 +58,27 @@ test('extract file', async t => {
 });
 
 test('error on 404', async t => {
-	t.throws(m('http://foo.bar/404'), 'Response code 404 (Not Found)');
+	await t.throws(m('http://foo.bar/404'), 'Response code 404 (Not Found)');
 });
 
 test('rename to valid filename', async t => {
-	await m('http://foo.bar/foo?bar.zip', __dirname);
+	await m('http://foo.bar/foo*bar.zip', __dirname);
 	t.true(await pathExists(path.join(__dirname, 'foo!bar.zip')));
 	await fsP.unlink(path.join(__dirname, 'foo!bar.zip'));
 });
 
 test('follow redirects', async t => {
 	t.true(isZip(await m('http://foo.bar/redirect.zip')));
+});
+
+test('hanle query string', async t => {
+	await m('http://foo.bar/querystring.zip?param=value', __dirname);
+	t.true(await pathExists(path.join(__dirname, 'querystring.zip')));
+	await fsP.unlink(path.join(__dirname, 'querystring.zip'));
+});
+
+test('hanle content dispositon', async t => {
+	await m('http://foo.bar/dispo', __dirname);
+	t.true(await pathExists(path.join(__dirname, 'dispo.zip')));
+	await fsP.unlink(path.join(__dirname, 'dispo.zip'));
 });


### PR DESCRIPTION
This turned out to be a lot more work than I expected, because the `get-stream` usage didn't allow access to the HTTP headers, so I had to rewrite quite much to get what I need.

The 404 test was broken on master (it uses a async function without await), by the way.

cc: @sindresorhus