### PR TITLE
Fix weirdness from using an older version of decompress

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "caw": "^2.0.0",
     "content-disposition": "^0.5.2",
-    "decompress": "^4.0.0",
+    "decompress": "^4.2.0",
     "ext-name": "^5.0.0",
     "file-type": "5.2.0",
     "filenamify": "^2.0.0",


### PR DESCRIPTION
For some reason `decompress@4.0.0` would occasionally give me an empty array instead of the contents of a tgz I had asked `download` to fetch and extract. Updating resolves this.