### PR TITLE
upgrade: deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,25 +26,25 @@
     "url"
   ],
   "dependencies": {
-    "caw": "^2.0.0",
+    "caw": "^2.0.1",
     "content-disposition": "^0.5.2",
-    "decompress": "^4.0.0",
+    "decompress": "^4.2.0",
     "ext-name": "^5.0.0",
-    "file-type": "5.2.0",
+    "file-type": "^7.6.0",
     "filenamify": "^2.0.0",
     "get-stream": "^3.0.0",
-    "got": "^7.0.0",
-    "make-dir": "^1.0.0",
-    "p-event": "^1.0.0",
+    "got": "^8.3.0",
+    "make-dir": "^1.2.0",
+    "p-event": "^1.3.0",
     "pify": "^3.0.0"
   },
   "devDependencies": {
     "ava": "*",
     "is-zip": "^1.0.0",
-    "nock": "^9.0.2",
+    "nock": "^9.2.3",
     "path-exists": "^3.0.0",
     "random-buffer": "^0.1.0",
-    "rimraf": "^2.2.8",
+    "rimraf": "^2.6.2",
     "xo": "*"
   }
 }


### PR DESCRIPTION
Another reason why I want to upgrade the dependencies is `got`.

The document of `got` in the document now points to the latest document, but the actual code depends on the version of 7.0, some options had changed, ex. `useElectornNet`.


