### PR TITLE
Fix agent uses wrong protocol after redirect to HTTPS when behind proxy

### DIFF
--- a/test.js
+++ b/test.js
@@ -31,7 +31,14 @@ test.before(() => {
 		.reply(200, randomBuffer(7928260))
 		.get('/redirect.zip')
 		.reply(302, null, {location: 'http://foo.bar/foo.zip'})
+		.get('/redirect-https.zip')
+		.reply(301, null, {location: 'https://foo.bar/foo-https.zip'})
 		.get('/filetype')
+		.replyWithFile(200, path.join(__dirname, 'fixture.zip'));
+
+	nock('https://foo.bar')
+		.persist()
+		.get('/foo-https.zip')
 		.replyWithFile(200, path.join(__dirname, 'fixture.zip'));
 });
 
@@ -77,6 +84,10 @@ test('rename to valid filename', async t => {
 
 test('follow redirects', async t => {
 	t.true(isZip(await m('http://foo.bar/redirect.zip')));
+});
+
+test('follow redirect to https', async t => {
+	t.true(isZip(await m('http://foo.bar/redirect-https.zip')));
 });
 
 test('handle query string', async t => {


### PR DESCRIPTION
After upgrading some dependencies our CI build failed due to `got` erroring out with an `MaxRedirectsError` when trying to [download pngquant](https://github.com/imagemin/pngquant-bin/blob/42091a7cfa0f862463d3292ddf192006fecdf7a4/lib/install.js#L14).

The pngquant server answeres the request with a redirect to HTTPS (status 301), so a new request is sent. For this new request the `download` module uses the same agent that was created for the initial request with the initial protocol (HTTP). This causes an endless loop when behind a corporate proxy since caw always sends the requests to HTTP port.

This merge requests fixes this by creating a new agent when the protocol differs after a redirect.

The reason why this showed up for us just now is that the download url for the pngquant sources changed between the version we used before and the current version. See https://github.com/imagemin/pngquant-bin/commit/172fd0edde7c0a5aeead42a94e8761949f780fc0#diff-f6618e1cc731d58106a806b7679a7616. 

Fixes #159.