### PR TITLE
Restore optional extraction functionality from download 4.x.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const path = require('path');
 const url = require('url');
 const caw = require('caw');
 const contentDisposition = require('content-disposition');
+const archiveType = require('archive-type');
 const decompress = require('decompress');
 const filenamify = require('filenamify');
 const getStream = require('get-stream');
@@ -96,13 +97,13 @@ module.exports = (uri, output, opts) => {
 		const [data, res] = result;
 
 		if (!output) {
-			return opts.extract ? decompress(data, opts) : data;
+			return opts.extract && archiveType(data) ? decompress(data, opts) : data;
 		}
 
 		const filename = opts.filename || filenamify(getFilename(res, data));
 		const outputFilepath = path.join(output, filename);
 
-		if (opts.extract) {
+		if (opts.extract && archiveType(data)) {
 			return decompress(data, path.dirname(outputFilepath), opts);
 		}
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "url"
   ],
   "dependencies": {
+    "archive-type": "^4.0.0",
     "caw": "^2.0.1",
     "content-disposition": "^0.5.2",
     "decompress": "^4.2.0",

--- a/test.js
+++ b/test.js
@@ -19,6 +19,8 @@ test.before(() => {
 		.reply(404)
 		.get('/foo.zip')
 		.replyWithFile(200, path.join(__dirname, 'fixture.zip'))
+		.get('/foo.js')
+		.replyWithFile(200, __filename)
 		.get('/querystring.zip').query({param: 'value'})
 		.replyWithFile(200, path.join(__dirname, 'fixture.zip'))
 		.get('/dispo')
@@ -70,6 +72,12 @@ test('extract file', async t => {
 	await m('http://foo.bar/foo.zip', __dirname, {extract: true});
 	t.true(await pathExists(path.join(__dirname, 'file.txt')));
 	await fsP.unlink(path.join(__dirname, 'file.txt'));
+});
+
+test('extract file that is not compressed', async t => {
+	await m('http://foo.bar/foo.js', __dirname, {extract: true});
+	t.true(await pathExists(path.join(__dirname, 'foo.js')));
+	await fsP.unlink(path.join(__dirname, 'foo.js'));
 });
 
 test('error on 404', async t => {


### PR DESCRIPTION
In download 4.x it was possible to set `extract: true` to download an
archive and a text file.  Since 5.x a silent error occurs on the text
file and its content is lost.

Uses archive-type to detect if a file is an archive before using
decompress on it.

This will make it possible to update bin-wrapper to upgrade the `download` component.