### PR TITLE
Pass parsed url to got to support basic auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ module.exports = (uri, output, opts) => {
 	}, opts);
 
 	const agent = caw(opts.proxy, {protocol});
-	const stream = got.stream(uri, Object.assign({agent}, opts))
+	const stream = got.stream(url.parse(uri), Object.assign({agent}, opts))
 		.on('redirect', (response, nextOptions) => {
 			const redirectProtocol = getProtocolFromUri(nextOptions.href);
 			if (redirectProtocol && redirectProtocol !== protocol) {


### PR DESCRIPTION
This allows for usage of things such as basic auth, and other features
that node's built-in url library support that `got` expects.

Confirmed that it no longer threw the error present in the upstream issue sindresorhus/got#184

```
Error: Basic authentication must be done with auth option                                                                                                      │$: git co master
    at normalizeArguments (~/code/project/node_modules/got/index.js:215:10)
```