### PR TITLE
Use fs-extra to prevent EMFILE errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
-const fs = require('fs');
 const path = require('path');
-const url = require('url');
+const {URL} = require('url');
+const fse = require('fs-extra');
 const caw = require('caw');
 const contentDisposition = require('content-disposition');
 const archiveType = require('archive-type');
@@ -10,13 +10,11 @@ const filenamify = require('filenamify');
 const getStream = require('get-stream');
 const got = require('got');
 const makeDir = require('make-dir');
-const pify = require('pify');
 const pEvent = require('p-event');
 const fileType = require('file-type');
 const extName = require('ext-name');
 
-const fsP = pify(fs);
-const filenameFromPath = res => path.basename(url.parse(res.requestUrl).pathname);
+const filenameFromPath = res => path.basename(new URL(res.requestUrl).pathname);
 
 const getExtFromMime = res => {
 	const header = res.headers['content-type'];
@@ -59,7 +57,7 @@ const getFilename = (res, data) => {
 };
 
 const getProtocolFromUri = uri => {
-	let {protocol} = url.parse(uri);
+	let {protocol} = new URL(uri);
 
 	if (protocol) {
 		protocol = protocol.slice(0, -1);
@@ -108,7 +106,7 @@ module.exports = (uri, output, opts) => {
 		}
 
 		return makeDir(path.dirname(outputFilepath))
-			.then(() => fsP.writeFile(outputFilepath, data))
+			.then(() => fse.writeFile(outputFilepath, data))
 			.then(() => data);
 	});
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"got": "^8.3.1",
 		"make-dir": "^1.2.0",
 		"p-event": "^2.1.0",
-		"pify": "^3.0.0"
+		"fs-extra": "^7.0.1"
 	},
 	"devDependencies": {
 		"ava": "*",

--- a/test.js
+++ b/test.js
@@ -1,16 +1,13 @@
-import fs from 'fs';
 import path from 'path';
+import fse from 'fs-extra';
 import contentDisposition from 'content-disposition';
 import getStream from 'get-stream';
 import isZip from 'is-zip';
 import nock from 'nock';
 import pathExists from 'path-exists';
-import pify from 'pify';
 import randomBuffer from 'random-buffer';
 import test from 'ava';
 import m from '.';
-
-const fsP = pify(fs);
 
 test.before(() => {
 	nock('http://foo.bar')
@@ -59,35 +56,37 @@ test('download a very large file', async t => {
 test('download and rename file', async t => {
 	await m('http://foo.bar/foo.zip', __dirname, {filename: 'bar.zip'});
 	t.true(await pathExists(path.join(__dirname, 'bar.zip')));
-	await fsP.unlink(path.join(__dirname, 'bar.zip'));
+	await fse.unlink(path.join(__dirname, 'bar.zip'));
 });
 
 test('save file', async t => {
 	await m('http://foo.bar/foo.zip', __dirname);
 	t.true(await pathExists(path.join(__dirname, 'foo.zip')));
-	await fsP.unlink(path.join(__dirname, 'foo.zip'));
+	await fse.unlink(path.join(__dirname, 'foo.zip'));
 });
 
 test('extract file', async t => {
 	await m('http://foo.bar/foo.zip', __dirname, {extract: true});
 	t.true(await pathExists(path.join(__dirname, 'file.txt')));
-	await fsP.unlink(path.join(__dirname, 'file.txt'));
+	await fse.unlink(path.join(__dirname, 'file.txt'));
 });
 
 test('extract file that is not compressed', async t => {
 	await m('http://foo.bar/foo.js', __dirname, {extract: true});
 	t.true(await pathExists(path.join(__dirname, 'foo.js')));
-	await fsP.unlink(path.join(__dirname, 'foo.js'));
+	await fse.unlink(path.join(__dirname, 'foo.js'));
 });
 
 test('error on 404', async t => {
-	await t.throws(m('http://foo.bar/404'), 'Response code 404 (Not Found)');
+	await t.throwsAsync(async () => {
+		await m('http://foo.bar/404');
+	}, 'Response code 404 (Not Found)');
 });
 
 test('rename to valid filename', async t => {
 	await m('http://foo.bar/foo*bar.zip', __dirname);
 	t.true(await pathExists(path.join(__dirname, 'foo!bar.zip')));
-	await fsP.unlink(path.join(__dirname, 'foo!bar.zip'));
+	await fse.unlink(path.join(__dirname, 'foo!bar.zip'));
 });
 
 test('follow redirects', async t => {
@@ -101,17 +100,17 @@ test('follow redirect to https', async t => {
 test('handle query string', async t => {
 	await m('http://foo.bar/querystring.zip?param=value', __dirname);
 	t.true(await pathExists(path.join(__dirname, 'querystring.zip')));
-	await fsP.unlink(path.join(__dirname, 'querystring.zip'));
+	await fse.unlink(path.join(__dirname, 'querystring.zip'));
 });
 
 test('handle content dispositon', async t => {
 	await m('http://foo.bar/dispo', __dirname);
 	t.true(await pathExists(path.join(__dirname, 'dispo.zip')));
-	await fsP.unlink(path.join(__dirname, 'dispo.zip'));
+	await fse.unlink(path.join(__dirname, 'dispo.zip'));
 });
 
 test('handle filename from file type', async t => {
 	await m('http://foo.bar/filetype', __dirname);
 	t.true(await pathExists(path.join(__dirname, 'filetype.zip')));
-	await fsP.unlink(path.join(__dirname, 'filetype.zip'));
+	await fse.unlink(path.join(__dirname, 'filetype.zip'));
 });


### PR DESCRIPTION
* Replace `url.parse` for URL contructor.
* Fix test for 404 error.
* Substitute usage of `fs` module for `fs-extra`. This will allow to use async methods without importing Promisify module, and prevent EMFILE errors that could happen.