### PR TITLE
feat: support URL rewriting

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	"dependencies": {
 		"archive-type": "^4.0.0",
 		"content-disposition": "^0.5.2",
+		"cosmiconfig": "^6.0.0",
 		"decompress": "^4.2.1",
 		"ext-name": "^5.0.0",
 		"file-type": "^11.1.0",

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,23 @@ const download = require('download');
 
 To work with proxies, read the [`got documentation`](https://github.com/sindresorhus/got#proxies).
 
+### Rewriting
+
+This feature allows downloading from mirrors, by supporting URL rewriting.
+
+Create a `.downloadrc` in you home directory or somewhere else that can be searched by [cosmiconfig](https://github.com/davidtheclark/cosmiconfig), with prefix replacing rules. For instance, rewriting the URLs to download image processing binary files:
+
+```json
+{
+  "rewrite": {
+    "https://raw.githubusercontent.com/imagemin/cwebp-bin/": "https://npm.taobao.org/mirrors/cwebp-bin/",
+    "https://raw.githubusercontent.com/imagemin/mozjpeg-bin/": "https://npm.taobao.org/mirrors/mozjpeg-bin/",
+    "https://raw.githubusercontent.com/imagemin/pngquant-bin/": "https://npm.taobao.org/mirrors/pngquant-bin/"
+  }
+}
+```
+
+Only prefixes will be matched for now.
 
 ## API
 


### PR DESCRIPTION
Allow rewriting URLs before download starts.
This is useful for cases with network problems. We can easily change the prefixes of the URLs to our mirrors by creating a `~/.downloadrc` like this:

```json
{
  "rewrite": {
    "https://raw.githubusercontent.com/imagemin/cwebp-bin/": "https://npm.taobao.org/mirrors/cwebp-bin/",
    "https://raw.githubusercontent.com/imagemin/mozjpeg-bin/": "https://npm.taobao.org/mirrors/mozjpeg-bin/",
    "https://raw.githubusercontent.com/imagemin/pngquant-bin/": "https://npm.taobao.org/mirrors/pngquant-bin/"
  }
}
```