### PR TITLE
Resolve `process.env.npm_config_strict_ssl` is a empty value

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,10 @@ function Download(opts) {
 		return new Download(opts);
 	}
 
-	this.opts = objectAssign({encoding: null}, opts);
+	this.opts = objectAssign({
+		encoding: null,
+		rejectUnauthorized: process.env.npm_config_strict_ssl !== 'false'
+	}, opts);
 	this.ware = new Ware();
 }
 


### PR DESCRIPTION
https://docs.npmjs.com/misc/config#strict-ssl

Tried to set strict-ssl to false in .nmprc file, but process.env.npm_config_strict_ssl return empty string.