### PR TITLE
fix(deps): bump got from 8.x.x to 11.8.2 [security] CVE-2021-33502

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - '12'
-  - '10'
+  - '14'
+  - '16'

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
-const {URL} = require('url');
 const contentDisposition = require('content-disposition');
 const archiveType = require('archive-type');
 const decompress = require('decompress');
@@ -63,15 +62,15 @@ module.exports = (uri, output, opts) => {
 		output = null;
 	}
 
-	opts = Object.assign({
-		encoding: null,
-		rejectUnauthorized: process.env.npm_config_strict_ssl !== 'false'
-	}, opts);
+	opts = {
+		rejectUnauthorized: process.env.npm_config_strict_ssl !== 'false',
+		...opts
+	};
 
 	const stream = got.stream(uri, opts);
 
 	const promise = pEvent(stream, 'response').then(res => {
-		const encoding = opts.encoding === null ? 'buffer' : opts.encoding;
+		const encoding = opts.encoding ? opts.encoding : 'buffer';
 		return Promise.all([getStream(stream, {encoding}), res]);
 	}).then(result => {
 		const [data, res] = result;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "github.com/kevva"
 	},
 	"engines": {
-		"node": ">=10"
+		"node": ">=14.16"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -33,7 +33,7 @@
 		"file-type": "^11.1.0",
 		"filenamify": "^3.0.0",
 		"get-stream": "^4.1.0",
-		"got": "^8.3.1",
+		"got": "^11.8.2",
 		"make-dir": "^2.1.0",
 		"p-event": "^2.1.0",
 		"pify": "^4.0.1"
@@ -41,10 +41,15 @@
 	"devDependencies": {
 		"ava": "^1.4.1",
 		"is-zip": "^1.0.0",
-		"nock": "^10.0.6",
+		"nock": "^13.1.0",
 		"path-exists": "^3.0.0",
 		"random-buffer": "^0.1.0",
 		"rimraf": "^3.0.0",
 		"xo": "^0.24.0"
+	},
+	"xo": {
+		"rules": {
+			"promise/prefer-await-to-then": 0
+		}
 	}
 }


### PR DESCRIPTION
Removes dependency on `normalize-url@2` through `got > cacheable-request`, as referenced in https://github.com/advisories/GHSA-px4h-xg32-q955

BREAKING CHANGE: got@11 requires node 14.16. Node 10/12 is no longer supported