### PR TITLE
Update all the stuff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  FORCE_COLOR: 2
+
+jobs:
+  test:
+    name: Node ${{ matrix.node }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [12, 14, 16, 18]
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install npm dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm run test-ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+/coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - '12'
-  - '10'

--- a/package.json
+++ b/package.json
@@ -10,10 +10,18 @@
 		"url": "github.com/kevva"
 	},
 	"engines": {
-		"node": ">=10"
+		"node": "^12.20.0 || ^14.14.0 || >=16.0.0"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"ava": "ava",
+		"xo": "xo",
+		"test": "npm run xo && npm run ava",
+		"test-ci": "npm run xo && c8 ava"
+	},
+	"main": "index.js",
+	"type": "module",
+	"exports": {
+		".": "./index.js"
 	},
 	"files": [
 		"index.js"
@@ -25,26 +33,35 @@
 		"request",
 		"url"
 	],
+	"c8": {
+		"reporter": [
+			"lcovonly",
+			"text"
+		]
+	},
 	"dependencies": {
 		"archive-type": "^4.0.0",
-		"content-disposition": "^0.5.2",
+		"content-disposition": "^0.5.4",
 		"decompress": "^4.2.1",
 		"ext-name": "^5.0.0",
-		"file-type": "^11.1.0",
-		"filenamify": "^3.0.0",
-		"get-stream": "^4.1.0",
-		"got": "^8.3.1",
-		"make-dir": "^2.1.0",
-		"p-event": "^2.1.0",
-		"pify": "^4.0.1"
+		"file-type": "^12.4.2",
+		"filenamify": "^5.1.1",
+		"get-stream": "^6.0.1",
+		"got": "^11.8.5",
+		"p-event": "^5.0.1"
 	},
 	"devDependencies": {
-		"ava": "^1.4.1",
+		"ava": "^4.3.0",
+		"c8": "^7.11.3",
 		"is-zip": "^1.0.0",
-		"nock": "^10.0.6",
-		"path-exists": "^3.0.0",
+		"nock": "^13.2.6",
+		"path-exists": "^5.0.0",
 		"random-buffer": "^0.1.0",
-		"rimraf": "^3.0.0",
-		"xo": "^0.24.0"
+		"xo": "^0.49.0"
+	},
+	"xo": {
+		"rules": {
+			"unicorn/prevent-abbreviations": "off"
+		}
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# download [![Build Status](https://travis-ci.org/kevva/download.svg?branch=master)](https://travis-ci.org/kevva/download)
+# download [![CI](https://github.com/kevva/download/actions/workflows/ci.yml/badge.svg)](https://github.com/kevva/download/actions/workflows/ci.yml)
 
 > Download and extract files
 
@@ -7,16 +7,16 @@
 
 ## Install
 
-```
-$ npm install download
+```sh
+npm install download
 ```
 
 
 ## Usage
 
 ```js
-const fs = require('fs');
-const download = require('download');
+import fs from 'node:fs';
+import download from 'download';
 
 (async () => {
 	await download('http://unicorn.com/foo.jpg', 'dist');
@@ -63,8 +63,8 @@ Same options as [`got`](https://github.com/sindresorhus/got#options) and [`decom
 
 ##### extract
 
-Type: `boolean`<br>
-Default: `false`
+* Type: `boolean`
+* Default: `false`
 
 If set to `true`, try extracting the file using [`decompress`](https://github.com/kevva/decompress).
 

--- a/test.js
+++ b/test.js
@@ -1,16 +1,17 @@
-import fs from 'fs';
-import path from 'path';
+import {promises as fs} from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 import test from 'ava';
 import contentDisposition from 'content-disposition';
 import getStream from 'get-stream';
 import isZip from 'is-zip';
 import nock from 'nock';
-import pathExists from 'path-exists';
-import pify from 'pify';
+import {pathExists} from 'path-exists';
 import randomBuffer from 'random-buffer';
-import m from '.';
+import download from './index.js';
 
-const fsP = pify(fs);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 test.before(() => {
 	nock('http://foo.bar')
@@ -25,12 +26,12 @@ test.before(() => {
 		.replyWithFile(200, path.join(__dirname, 'fixture.zip'))
 		.get('/dispo')
 		.replyWithFile(200, path.join(__dirname, 'fixture.zip'), {
-			'Content-Disposition': contentDisposition('dispo.zip')
+			'Content-Disposition': contentDisposition('dispo.zip'),
 		})
 		.get('/foo*bar.zip')
 		.replyWithFile(200, path.join(__dirname, 'fixture.zip'))
 		.get('/large.bin')
-		.reply(200, randomBuffer(7928260))
+		.reply(200, randomBuffer(7_928_260))
 		.get('/redirect.zip')
 		.reply(302, null, {location: 'http://foo.bar/foo.zip'})
 		.get('/redirect-https.zip')
@@ -45,73 +46,74 @@ test.before(() => {
 });
 
 test('download as stream', async t => {
-	t.true(isZip(await getStream.buffer(m('http://foo.bar/foo.zip'))));
+	t.true(isZip(await getStream.buffer(download('http://foo.bar/foo.zip'))));
 });
 
 test('download as promise', async t => {
-	t.true(isZip(await m('http://foo.bar/foo.zip')));
+	t.true(isZip(await download('http://foo.bar/foo.zip')));
 });
 
 test('download a very large file', async t => {
-	t.is((await getStream.buffer(m('http://foo.bar/large.bin'))).length, 7928260);
+	const stream = await getStream.buffer(download('http://foo.bar/large.bin'));
+	t.is(stream.length, 7_928_260);
 });
 
 test('download and rename file', async t => {
-	await m('http://foo.bar/foo.zip', __dirname, {filename: 'bar.zip'});
+	await download('http://foo.bar/foo.zip', __dirname, {filename: 'bar.zip'});
 	t.true(await pathExists(path.join(__dirname, 'bar.zip')));
-	await fsP.unlink(path.join(__dirname, 'bar.zip'));
+	await fs.unlink(path.join(__dirname, 'bar.zip'));
 });
 
 test('save file', async t => {
-	await m('http://foo.bar/foo.zip', __dirname);
+	await download('http://foo.bar/foo.zip', __dirname);
 	t.true(await pathExists(path.join(__dirname, 'foo.zip')));
-	await fsP.unlink(path.join(__dirname, 'foo.zip'));
+	await fs.unlink(path.join(__dirname, 'foo.zip'));
 });
 
 test('extract file', async t => {
-	await m('http://foo.bar/foo.zip', __dirname, {extract: true});
+	await download('http://foo.bar/foo.zip', __dirname, {extract: true});
 	t.true(await pathExists(path.join(__dirname, 'file.txt')));
-	await fsP.unlink(path.join(__dirname, 'file.txt'));
+	await fs.unlink(path.join(__dirname, 'file.txt'));
 });
 
 test('extract file that is not compressed', async t => {
-	await m('http://foo.bar/foo.js', __dirname, {extract: true});
+	await download('http://foo.bar/foo.js', __dirname, {extract: true});
 	t.true(await pathExists(path.join(__dirname, 'foo.js')));
-	await fsP.unlink(path.join(__dirname, 'foo.js'));
+	await fs.unlink(path.join(__dirname, 'foo.js'));
 });
 
 test('error on 404', async t => {
-	await t.throwsAsync(m('http://foo.bar/404'), 'Response code 404 (Not Found)');
+	await t.throwsAsync(download('http://foo.bar/404'), undefined, 'Response code 404 (Not Found)');
 });
 
 test('rename to valid filename', async t => {
-	await m('http://foo.bar/foo*bar.zip', __dirname);
+	await download('http://foo.bar/foo*bar.zip', __dirname);
 	t.true(await pathExists(path.join(__dirname, 'foo!bar.zip')));
-	await fsP.unlink(path.join(__dirname, 'foo!bar.zip'));
+	await fs.unlink(path.join(__dirname, 'foo!bar.zip'));
 });
 
 test('follow redirects', async t => {
-	t.true(isZip(await m('http://foo.bar/redirect.zip')));
+	t.true(isZip(await download('http://foo.bar/redirect.zip')));
 });
 
 test('follow redirect to https', async t => {
-	t.true(isZip(await m('http://foo.bar/redirect-https.zip')));
+	t.true(isZip(await download('http://foo.bar/redirect-https.zip')));
 });
 
 test('handle query string', async t => {
-	await m('http://foo.bar/querystring.zip?param=value', __dirname);
+	await download('http://foo.bar/querystring.zip?param=value', __dirname);
 	t.true(await pathExists(path.join(__dirname, 'querystring.zip')));
-	await fsP.unlink(path.join(__dirname, 'querystring.zip'));
+	await fs.unlink(path.join(__dirname, 'querystring.zip'));
 });
 
-test('handle content dispositon', async t => {
-	await m('http://foo.bar/dispo', __dirname);
+test('handle content disposition', async t => {
+	await download('http://foo.bar/dispo', __dirname);
 	t.true(await pathExists(path.join(__dirname, 'dispo.zip')));
-	await fsP.unlink(path.join(__dirname, 'dispo.zip'));
+	await fs.unlink(path.join(__dirname, 'dispo.zip'));
 });
 
 test('handle filename from file type', async t => {
-	await m('http://foo.bar/filetype', __dirname);
+	await download('http://foo.bar/filetype', __dirname);
 	t.true(await pathExists(path.join(__dirname, 'filetype.zip')));
-	await fsP.unlink(path.join(__dirname, 'filetype.zip'));
+	await fs.unlink(path.join(__dirname, 'filetype.zip'));
 });


### PR DESCRIPTION
* switch to ESM, require Node.js 12
* switch to GitHub Actions
* remove pify, make-dir and rimraf packages
* add coverage with c8
* update all packages to the latest version except for file-type and got they require further code changes:
  * got now throws on unsupported options being passed like `extract`
  * file-type >= 13.0.0 is async only

Closes #212, closes #204,  closes #200

CI run: https://github.com/XhmikosR/download/actions

/CC @sindresorhus 