### PR TITLE
disable es-lint rules only on working functions that trigger test error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,4 @@
 'use strict';
-
-/* eslint-disable promise/prefer-await-to-then */
-
 const fs = require('fs');
 const path = require('path');
 const {URL} = require('url'); // eslint-disable-line node/prefer-global/url
@@ -73,10 +70,10 @@ module.exports = (uri, output, opts) => {
 
 	const stream = got.stream(uri, opts);
 
-	const promise = pEvent(stream, 'response').then(res => {
+	const promise = pEvent(stream, 'response').then(res => { // eslint-disable-line promise/prefer-await-to-then
 		const encoding = opts.encoding === null ? 'buffer' : opts.encoding;
 		return Promise.all([getStream(stream, {encoding}), res]);
-	}).then(result => {
+	}).then(result => { // eslint-disable-line promise/prefer-await-to-then
 		const [data, res] = result;
 
 		if (!output) {
@@ -91,11 +88,11 @@ module.exports = (uri, output, opts) => {
 		}
 
 		return makeDir(path.dirname(outputFilepath))
-			.then(() => fsP.writeFile(outputFilepath, data))
-			.then(() => data);
+			.then(() => fsP.writeFile(outputFilepath, data)) // eslint-disable-line promise/prefer-await-to-then
+			.then(() => data); // eslint-disable-line promise/prefer-await-to-then
 	});
 
-	stream.then = promise.then.bind(promise);
+	stream.then = promise.then.bind(promise); // eslint-disable-line promise/prefer-await-to-then
 	stream.catch = promise.catch.bind(promise);
 
 	return stream;

--- a/index.js
+++ b/index.js
@@ -66,10 +66,10 @@ module.exports = (uri, output, opts) => {
 		output = null;
 	}
 
-	opts = Object.assign({
+	opts = Object.assign({ // eslint-disable-line prefer-object-spread
 		encoding: null,
 		rejectUnauthorized: process.env.npm_config_strict_ssl !== 'false'
-	}, opts); // eslint-disable-line prefer-object-spread
+	}, opts);
 
 	const stream = got.stream(uri, opts);
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 'use strict';
+
+/* eslint-disable promise/prefer-await-to-then */
+
 const fs = require('fs');
 const path = require('path');
-const {URL} = require('url');
+const {URL} = require('url'); // eslint-disable-line node/prefer-global/url
 const contentDisposition = require('content-disposition');
 const archiveType = require('archive-type');
 const decompress = require('decompress');
@@ -66,7 +69,7 @@ module.exports = (uri, output, opts) => {
 	opts = Object.assign({
 		encoding: null,
 		rejectUnauthorized: process.env.npm_config_strict_ssl !== 'false'
-	}, opts);
+	}, opts); // eslint-disable-line prefer-object-spread
 
 	const stream = got.stream(uri, opts);
 


### PR DESCRIPTION
disable some es lint rules which are too strict and are triggering test error