### PR TITLE
feat: handle uri-encoded filenames

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,9 +13,11 @@ const pify = require('pify');
 const pEvent = require('p-event');
 const fileType = require('file-type');
 const extName = require('ext-name');
+const crypto = require('crypto');
 
 const fsP = pify(fs);
 const filenameFromPath = res => path.basename(new URL(res.requestUrl).pathname);
+const randName = len => crypto.randomBytes(Math.round(len / 2)).toString('hex')
 
 const getExtFromMime = res => {
 	const header = res.headers['content-type'];
@@ -80,7 +82,7 @@ module.exports = (uri, output, opts) => {
 			return opts.extract && archiveType(data) ? decompress(data, opts) : data;
 		}
 
-		const filename = opts.filename || filenamify(getFilename(res, data));
+		const filename = opts.filename || filenamify(getFilename(res, data)) || randName(16);
 		const outputFilepath = path.join(output, filename);
 
 		if (opts.extract && archiveType(data)) {
@@ -97,3 +99,4 @@ module.exports = (uri, output, opts) => {
 
 	return stream;
 };
+

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ module.exports = (uri, output, opts) => {
 
 		return makeDir(path.dirname(outputFilepath))
 			.then(() => fsP.writeFile(outputFilepath, data))
-			.then(() => data);
+			.then(() => ({data,outputFilepath}));
 	});
 
 	stream.then = promise.then.bind(promise);

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const getFilename = (res, data) => {
 		const parsed = contentDisposition.parse(header);
 
 		if (parsed.parameters && parsed.parameters.filename) {
-			return parsed.parameters.filename;
+			return decodeURIComponent(parsed.parameters.filename);
 		}
 	}
 
@@ -54,7 +54,7 @@ const getFilename = (res, data) => {
 		}
 	}
 
-	return filename;
+	return decodeURIComponent(filename);
 };
 
 module.exports = (uri, output, opts) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tpp/download2",
-	"version": "8.1.0",
+	"version": "8.1.1",
 	"description": "Download and extract files",
 	"license": "MIT",
 	"repository": "theproductiveprogrammer/download",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,9 @@
 {
-	"name": "download",
-	"version": "8.0.0",
+	"name": "@tpp/download2",
+	"version": "8.1.0",
 	"description": "Download and extract files",
 	"license": "MIT",
-	"repository": "kevva/download",
-	"author": {
-		"email": "kevinmartensson@gmail.com",
-		"name": "Kevin Mårtensson",
-		"url": "github.com/kevva"
-	},
+	"repository": "theproductiveprogrammer/download",
 	"engines": {
 		"node": ">=10"
 	},


### PR DESCRIPTION
Sometimes the downloaded files are uri-encoded. For example:

https://www.ibm.com/downloads/cas/YE8GYW97

This returns the filename: "'ESG%3A%20Storage%27s%20Role%20in%20Addressing%20the%20Challenges%20of%20Ensuring%20Cyber%20Resilience.pdf"

Using `filenamify()` on this filename keeps the uri-encoding and truncates the extension as well:

```js
> filenamify('ESG%3A%20Storage%27s%20Role%20in%20Addressing%20the%20Challenges%20of%20Ensuring%20Cyber%20Resilience.pdf')
'ESG%3A%20Storage%27s%20Role%20in%20Addressing%20the%20Challenges%20of%20Ensuring%20Cyber%20Resilienc'
```

To handle such cases we should decode any url-encodings as I have done in this PR. That cleans up the filename and stores it correctly as well.

Before fix:
```
download('https://www.ibm.com/downloads/cas/YE8GYW97', 'dist');
// dist/ESG%3A%20Storage%27s%20Role%20in%20Addressing%20the%20Challenges%20of%20Ensuring%20Cyber%20Resilienc
```
After fix:
```
download('https://www.ibm.com/downloads/cas/YE8GYW97', 'dist');
// dist/ESG! Storage's Role in Addressing the Challenges of Ensuring Cyber Resilience.pdf
```